### PR TITLE
Add API endpoint for user creation

### DIFF
--- a/APIGateway/ocelot.json
+++ b/APIGateway/ocelot.json
@@ -10,7 +10,7 @@
         }
       ],
       "UpstreamPathTemplate": "/user",
-      "UpstreamHttpMethod": [ "GET" ]
+      "UpstreamHttpMethod": [ "GET", "POST" ]
     },
     {
       "DownstreamPathTemplate": "/api/tweetserver",

--- a/UserManagement/Controllers/UserServiceController.cs
+++ b/UserManagement/Controllers/UserServiceController.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using UserManagement.Data;
+using static UserManagement.UserRequest;
 
 namespace UserManagement.Controllers
 {
@@ -7,12 +10,52 @@ namespace UserManagement.Controllers
     [Route("api/user")]
     public class UserServiceController : ControllerBase
     {
+        private readonly AppDbContext _context;
+
+        public UserServiceController(AppDbContext context)
+        {
+            _context = context;
+        }
+
         [Authorize]
         [HttpGet]
         public IActionResult GetUsers()
         {
             var users = new List<string> { "Jan", "User2" };
             return Ok(users);
+        }
+
+        [Authorize]
+        [HttpPost]
+        public async Task<IActionResult> CreateUser([FromBody] CreateUserRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            if (await _context.Users.AnyAsync(u => u.Id == request.Id))
+            {
+                return Conflict("User already exists.");
+            }
+
+            var user = new User
+            {
+                Id = request.Id,
+                Username = request.Username,
+                Bio = request.Bio,
+                Auth0Id = request.Id.ToString(),
+                DisplayName = request.Username,
+                Email = string.Empty,
+                ProfilePictureUrl = null,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            _context.Users.Add(user);
+            await _context.SaveChangesAsync();
+
+            return Ok(new { user.Id, user.Username, user.Bio });
         }
     }
 }

--- a/UserManagement/CreateUserRequest.cs
+++ b/UserManagement/CreateUserRequest.cs
@@ -1,0 +1,9 @@
+namespace UserManagement
+{
+    public class CreateUserRequest
+    {
+        public Guid Id { get; set; }
+        public string Username { get; set; }
+        public string? Bio { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- create `CreateUserRequest` model for user registration
- implement POST `/api/user` endpoint in `UserServiceController`
- forward POST requests through the API gateway

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684820c23f748331bf532fbbce1f9205